### PR TITLE
Use async PostCSS interface.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ module.exports = ({ types: t }) => ({
 
       // const processed = postcss(plugins).process(css, options).css
       const { plugins, options } = deasyncPromise(postcssrc())
-      ;({ css } = postcss(plugins).process(css, options))
+      ;({ css } = deasyncPromise(postcss(plugins).process(css, options)))
 
       const { quasiTerms, expressionTerms } = splitExpressions(css)
       const quasisAst = buildQuasisAst(t, quasiTerms)


### PR DESCRIPTION
Async PostCSS plugins only work with the Promise-based PostCSS API, so this PR wraps the call to `postcss.process` in `deasyncPromise` as well. Thanks for putting together such a clever package!